### PR TITLE
Log error messages on failed requests.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,9 +96,9 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
     /**
      * @param $message
      */
-    public function logDebug($message)
+    public function logDebug($message, $context = [])
     {
-        $this->logger->debug('[Http]' . $message);
+        $this->logger->debug('[Http]' . $message, $context);
     }
 
     /**
@@ -121,6 +121,7 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
                     $request->callResolve($response);
                 }, function ($error) use ($requestId, $request) {
                     $this->logDebug('[' . $requestId . ']Error during request');
+                    $this->logDebug('[' . $requestId . ']', [$error->getMessage()]);
                     $request->callReject($error);
                 });
 
@@ -148,6 +149,7 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
                     $request->callResolve($response);
                 }, function ($error) use ($requestId, $request) {
                     $this->logDebug('[' . $requestId . ']Error during request');
+                    $this->logDebug('[' . $requestId . ']', [$error->getMessage()]);
                     $request->callReject($error);
                 });
 


### PR DESCRIPTION
Reddit was blocking requests because the bot was using guzzle's default user agent. This would have made it a tad easier to see why. 

This will put something like the following in your log on a failed request:

> [2017-03-24 18:42:23] phergie.DEBUG: [Http][58d5a0cf3ccc8] ["Client error response [url] http://not-a-real-url.com/ [status code] 429 [reason phrase] Too Many Requests"] []